### PR TITLE
Add watchOS MQTT WebSocket sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,38 @@
 # MQTT watchOS Sample
 
-Dieses Repository enthält eine minimale watchOS Beispielapplikation, die zeigt, wie man mit [MQTTNio](https://github.com/adam-fowler/mqtt-nio) über WebSockets eine Verbindung zu einem MQTT Broker von einer eigenständigen Apple Watch Anwendung aufbaut. Die App visualisiert den Verbindungsstatus, listet eintreffende Nachrichten aus dem `watch/#` Topic und bietet einen Button, der "Hello MQTT!" auf `watch/hello` publiziert.
+This repository contains a minimal watchOS sample application that demonstrates how to establish a WebSocket connection from an independent Apple Watch app to an MQTT broker using [MQTTNio](https://github.com/adam-fowler/mqtt-nio). The app visualizes the connection status, lists incoming messages from the `watch/#` topic, and exposes a button that publishes “Hello MQTT!” to `watch/hello`.
 
-## Projektstruktur
+## Project structure
 
 ```
 WatchMQTTSample/
 └── WatchMQTTSample/
-    ├── ContentView.swift          // SwiftUI Oberfläche
-    ├── MQTTWatchClient.swift      // MQTTNio Integration
-    ├── MessageEntry.swift         // Modell für eingehende Nachrichten
-    └── MQTTWatchSampleApp.swift   // App Entry Point
+    ├── ContentView.swift          // SwiftUI interface
+    ├── MQTTWatchClient.swift      // MQTTNio integration
+    ├── MessageEntry.swift         // Model for incoming messages
+    └── MQTTWatchSampleApp.swift   // App entry point
 ```
 
-Die Dateien können einfach in ein neues **watchOS App** Projekt in Xcode kopiert werden. MQTTNio wird als Swift Package eingebunden.
+You can copy the files into a new **watchOS App** project in Xcode. MQTTNio is integrated as a Swift Package.
 
-## Vorbereitung in Xcode
+## Xcode setup
 
-1. Erstelle in Xcode ein neues Projekt vom Typ **watchOS App** (SwiftUI, minimal watchOS 9).
-2. Aktiviere unter _General → Deployment_ die Option **App is independent**, damit die App auch ohne gekoppeltes iPhone über LTE funktionieren kann.
-3. Füge unter _Signing & Capabilities_ die Berechtigung **Background Modes → Background fetch** hinzu, um MQTT Verbindungen stabil zu halten.
-4. Öffne _File → Add Packages…_ und füge das Package `https://github.com/adam-fowler/mqtt-nio.git` mit der aktuellen Version hinzu.
-5. Ersetze die automatisch generierten Dateien in der Watch App Zielgruppe mit den Dateien aus diesem Repository.
+1. Create a new **watchOS App** project in Xcode (SwiftUI, minimum watchOS 9).
+2. Enable **App is independent** under _General → Deployment_ so the app can operate over LTE without a paired iPhone.
+3. Add **Background Modes → Background fetch** under _Signing & Capabilities_ to keep MQTT connections stable.
+4. Open _File → Add Packages…_ and add the package `https://github.com/adam-fowler/mqtt-nio.git` at the current version.
+5. Replace the auto-generated files in the watch app target with the files from this repository.
 
-Die Standard-Konfiguration im Code verbindet sich verschlüsselt via WebSocket (`wss`) mit dem öffentlichen Testbroker `broker.emqx.io` auf Port `8084`. Passe `MQTTWatchClient.Configuration` nach Bedarf (Host, Pfad, Zugangsdaten) an.
+The default configuration in the code connects securely via WebSocket (`wss`) to the public test broker `broker.emqx.io` on port `8084`. Adjust `MQTTWatchClient.Configuration` as needed (host, path, credentials).
 
-## Laufzeitverhalten
+## Runtime behavior
 
-* Beim Start stellt die App eine MQTT WebSocket-Verbindung her und abonniert `watch/#`.
-* Eingehende Nachrichten erscheinen in einer Liste, neueste Einträge oben.
-* Der Button **Send Hello** publiziert den Text "Hello MQTT!" auf `watch/hello`.
-* Bei Verbindungsverlust versucht die App automatisch einen Reconnect.
+* On launch, the app creates an MQTT WebSocket connection and subscribes to `watch/#`.
+* Incoming messages appear in a list, with the latest entries at the top.
+* The **Send Hello** button publishes the text “Hello MQTT!” to `watch/hello`.
+* If the connection drops, the app automatically attempts to reconnect.
 
-## Hinweise
+## Notes
 
-* Für produktive Einsätze sollten Zertifikate validiert, Fehlerzustände ausführlicher behandelt und ein persistentes Speichern der Nachrichten umgesetzt werden.
-* Auf der Watch empfiehlt sich, den Broker mit kurzen Keep-Alive Intervallen und QoS 1 zu betreiben, um Mobilfunk-Nutzung zu optimieren.
+* For production usage you should validate certificates, handle error states more comprehensively, and persist messages locally.
+* On the watch it is advisable to configure the broker with short keep-alive intervals and QoS 1 to optimize cellular usage.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ You can copy the files into a new **watchOS App** project in Xcode. MQTTNio is i
 4. Open _File → Add Packages…_ and add the package `https://github.com/adam-fowler/mqtt-nio.git` at the current version.
 5. Replace the auto-generated files in the watch app target with the files from this repository.
 
-The default configuration in the code connects securely via WebSocket (`wss`) to the public test broker `broker.emqx.io` on port `8084`. Adjust `MQTTWatchClient.Configuration` as needed (host, path, credentials).
+The default configuration in the code connects via WebSocket to the public HiveMQ broker `broker.hivemq.com` on port `8000`. Adjust `MQTTWatchClient.Configuration` as needed (host, TLS usage, path, credentials).
 
 ## Runtime behavior
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,38 @@
+# MQTT watchOS Sample
 
+Dieses Repository enthält eine minimale watchOS Beispielapplikation, die zeigt, wie man mit [MQTTNio](https://github.com/adam-fowler/mqtt-nio) über WebSockets eine Verbindung zu einem MQTT Broker von einer eigenständigen Apple Watch Anwendung aufbaut. Die App visualisiert den Verbindungsstatus, listet eintreffende Nachrichten aus dem `watch/#` Topic und bietet einen Button, der "Hello MQTT!" auf `watch/hello` publiziert.
+
+## Projektstruktur
+
+```
+WatchMQTTSample/
+└── WatchMQTTSample/
+    ├── ContentView.swift          // SwiftUI Oberfläche
+    ├── MQTTWatchClient.swift      // MQTTNio Integration
+    ├── MessageEntry.swift         // Modell für eingehende Nachrichten
+    └── MQTTWatchSampleApp.swift   // App Entry Point
+```
+
+Die Dateien können einfach in ein neues **watchOS App** Projekt in Xcode kopiert werden. MQTTNio wird als Swift Package eingebunden.
+
+## Vorbereitung in Xcode
+
+1. Erstelle in Xcode ein neues Projekt vom Typ **watchOS App** (SwiftUI, minimal watchOS 9).
+2. Aktiviere unter _General → Deployment_ die Option **App is independent**, damit die App auch ohne gekoppeltes iPhone über LTE funktionieren kann.
+3. Füge unter _Signing & Capabilities_ die Berechtigung **Background Modes → Background fetch** hinzu, um MQTT Verbindungen stabil zu halten.
+4. Öffne _File → Add Packages…_ und füge das Package `https://github.com/adam-fowler/mqtt-nio.git` mit der aktuellen Version hinzu.
+5. Ersetze die automatisch generierten Dateien in der Watch App Zielgruppe mit den Dateien aus diesem Repository.
+
+Die Standard-Konfiguration im Code verbindet sich verschlüsselt via WebSocket (`wss`) mit dem öffentlichen Testbroker `broker.emqx.io` auf Port `8084`. Passe `MQTTWatchClient.Configuration` nach Bedarf (Host, Pfad, Zugangsdaten) an.
+
+## Laufzeitverhalten
+
+* Beim Start stellt die App eine MQTT WebSocket-Verbindung her und abonniert `watch/#`.
+* Eingehende Nachrichten erscheinen in einer Liste, neueste Einträge oben.
+* Der Button **Send Hello** publiziert den Text "Hello MQTT!" auf `watch/hello`.
+* Bei Verbindungsverlust versucht die App automatisch einen Reconnect.
+
+## Hinweise
+
+* Für produktive Einsätze sollten Zertifikate validiert, Fehlerzustände ausführlicher behandelt und ein persistentes Speichern der Nachrichten umgesetzt werden.
+* Auf der Watch empfiehlt sich, den Broker mit kurzen Keep-Alive Intervallen und QoS 1 zu betreiben, um Mobilfunk-Nutzung zu optimieren.

--- a/WatchMQTTSample/WatchMQTTSample/ContentView.swift
+++ b/WatchMQTTSample/WatchMQTTSample/ContentView.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+
+struct ContentView: View {
+    @EnvironmentObject private var client: MQTTWatchClient
+
+    var body: some View {
+        VStack(spacing: 12) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Status")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                HStack {
+                    Circle()
+                        .fill(client.isConnected ? Color.green : Color.red)
+                        .frame(width: 8, height: 8)
+                    Text(client.connectionStatus)
+                        .font(.footnote)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.7)
+                        .accessibilityIdentifier("statusLabel")
+                }
+            }
+
+            List {
+                ForEach(client.messages.reversed()) { entry in
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(entry.topic)
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                        Text(entry.payload)
+                            .font(.body)
+                    }
+                }
+            }
+            .listStyle(.carousel)
+
+            Button(action: client.publishGreeting) {
+                Text("Send Hello")
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(!client.isConnected)
+        }
+        .padding(.vertical, 8)
+        .task {
+            await client.connectIfNeeded()
+        }
+        .onReceive(client.reconnectPublisher) { _ in
+            Task {
+                await client.connectIfNeeded(force: true)
+            }
+        }
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+            .environmentObject(MQTTWatchClient.preview)
+    }
+}

--- a/WatchMQTTSample/WatchMQTTSample/MQTTWatchClient.swift
+++ b/WatchMQTTSample/WatchMQTTSample/MQTTWatchClient.swift
@@ -21,10 +21,10 @@ final class MQTTWatchClient: ObservableObject {
         var password: String?
 
         static let `default` = Configuration(
-            host: "broker.emqx.io",
-            port: 8084,
+            host: "broker.hivemq.com",
+            port: 8000,
             path: "/mqtt",
-            useTLS: true,
+            useTLS: false,
             username: nil,
             password: nil
         )

--- a/WatchMQTTSample/WatchMQTTSample/MQTTWatchClient.swift
+++ b/WatchMQTTSample/WatchMQTTSample/MQTTWatchClient.swift
@@ -1,0 +1,266 @@
+import Combine
+import Foundation
+import MQTTNIO
+import NIO
+import NIOSSL
+
+@MainActor
+final class MQTTWatchClient: ObservableObject {
+    enum ConnectionState {
+        case disconnected
+        case connecting
+        case connected
+    }
+
+    struct Configuration {
+        var host: String
+        var port: Int
+        var path: String
+        var useTLS: Bool
+        var username: String?
+        var password: String?
+
+        static let `default` = Configuration(
+            host: "broker.emqx.io",
+            port: 8084,
+            path: "/mqtt",
+            useTLS: true,
+            username: nil,
+            password: nil
+        )
+    }
+
+    @Published private(set) var connectionStatus: String = "Disconnected"
+    @Published private(set) var messages: [MessageEntry] = []
+
+    var isConnected: Bool { state == .connected }
+
+    let reconnectPublisher = PassthroughSubject<Void, Never>()
+
+    static let preview: MQTTWatchClient = {
+        let client = MQTTWatchClient(configuration: .default, eventLoopGroupProvider: .singleton)
+        client.connectionStatus = "Connected"
+        client.messages = [
+            MessageEntry(topic: "watch/preview", payload: "Hello MQTT!", timestamp: Date())
+        ]
+        client.state = .connected
+        return client
+    }()
+
+    private let configuration: Configuration
+    private let eventLoopGroupProvider: EventLoopProvider
+    private var eventLoopGroup: EventLoopGroup?
+    private var client: MQTTClient?
+    private var state: ConnectionState = .disconnected {
+        didSet {
+            switch state {
+            case .disconnected:
+                connectionStatus = "Disconnected"
+            case .connecting:
+                connectionStatus = "Connecting…"
+            case .connected:
+                connectionStatus = "Connected"
+            }
+        }
+    }
+
+    init(configuration: Configuration = .default, eventLoopGroupProvider: EventLoopProvider = .createNew) {
+        self.configuration = configuration
+        self.eventLoopGroupProvider = eventLoopGroupProvider
+    }
+
+    deinit {
+        if let eventLoopGroup {
+            eventLoopGroup.shutdownGracefully { _ in }
+        }
+    }
+
+    func connectIfNeeded(force: Bool = false) async {
+        guard force || state == .disconnected else { return }
+        state = .connecting
+
+        do {
+            let client = try await makeClient(force: force)
+            try await connect(client: client)
+            try await subscribe(client: client)
+            state = .connected
+        } catch {
+            state = .disconnected
+            connectionStatus = "Error: \(error.localizedDescription)"
+            scheduleReconnect()
+        }
+    }
+
+    func publishGreeting() {
+        Task {
+            do {
+                guard let client else { throw MQTTWatchError.notConnected }
+                var buffer = ByteBufferAllocator().buffer(capacity: 0)
+                buffer.writeString("Hello MQTT!")
+                try await withCheckedThrowingContinuation { continuation in
+                    client.publish(to: "watch/hello", payload: buffer, qos: .atLeastOnce).whenComplete { result in
+                        switch result {
+                        case .success:
+                            continuation.resume()
+                        case .failure(let error):
+                            continuation.resume(throwing: error)
+                        }
+                    }
+                }
+            } catch {
+                await MainActor.run {
+                    self.connectionStatus = "Publish failed: \(error.localizedDescription)"
+                    self.state = .disconnected
+                    self.scheduleReconnect()
+                }
+            }
+        }
+    }
+
+    // MARK: - Private helpers
+
+    private func makeClient(force: Bool) async throws -> MQTTClient {
+        if force {
+            try await tearDownClient()
+        }
+
+        if let client {
+            return client
+        }
+
+        let eventLoopGroup = try await resolveEventLoopGroup()
+        let configuration = try mqttConfiguration()
+        let client = MQTTClient(configuration: configuration, eventLoopGroupProvider: .shared(eventLoopGroup))
+
+        client.addMessageListener { [weak self] message, _ in
+            guard let self else { return }
+            let payload: String
+            if var buffer = message.payload {
+                payload = buffer.readString(length: buffer.readableBytes) ?? ""
+            } else {
+                payload = ""
+            }
+
+            Task { @MainActor in
+                self.messages.append(MessageEntry(topic: message.topicName, payload: payload, timestamp: Date()))
+                self.trimMessagesIfNeeded()
+            }
+        }
+
+        self.client = client
+        return client
+    }
+
+    private func connect(client: MQTTClient) async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            client.connect().whenComplete { result in
+                switch result {
+                case .success:
+                    continuation.resume()
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+
+    private func subscribe(client: MQTTClient) async throws {
+        let subscriptions = [MQTTSubscribeInfo(topicFilter: "watch/#", qos: .atLeastOnce)]
+        try await withCheckedThrowingContinuation { continuation in
+            client.subscribe(to: subscriptions).whenComplete { result in
+                switch result {
+                case .success:
+                    continuation.resume()
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+
+    private func mqttConfiguration() throws -> MQTTConfiguration {
+        var tlsConfiguration: TLSConfiguration? = nil
+        if configuration.useTLS {
+            tlsConfiguration = .makeClientConfiguration()
+        }
+
+        return MQTTConfiguration(
+            target: .host(configuration.host, port: configuration.port),
+            protocolVersion: .version311,
+            clientId: "watch-\(UUID().uuidString.prefix(8))",
+            clean: true,
+            keepAliveInterval: .seconds(30),
+            connectTimeout: .seconds(5),
+            tlsConfiguration: tlsConfiguration,
+            transportConfig: .websocket(path: configuration.path, maxFrameSize: 1 << 14, additionalHTTPHeaders: [:]),
+            username: configuration.username,
+            password: configuration.password
+        )
+    }
+
+    private func resolveEventLoopGroup() async throws -> EventLoopGroup {
+        if let eventLoopGroup {
+            return eventLoopGroup
+        }
+
+        let group: EventLoopGroup
+        switch eventLoopGroupProvider {
+        case .createNew:
+            group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        case .shared(let existing):
+            group = existing
+        case .singleton:
+            group = MultiThreadedEventLoopGroup.singleton
+        }
+        eventLoopGroup = group
+        return group
+    }
+
+    private func tearDownClient() async throws {
+        guard let client else { return }
+        self.client = nil
+        try await withCheckedThrowingContinuation { continuation in
+            client.disconnect().whenComplete { result in
+                switch result {
+                case .success:
+                    continuation.resume()
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+
+    private func trimMessagesIfNeeded(maxCount: Int = 20) {
+        if messages.count > maxCount {
+            messages.removeFirst(messages.count - maxCount)
+        }
+    }
+
+    private func scheduleReconnect(delay seconds: Double = 5) {
+        Task { [weak self] in
+            try? await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+            await MainActor.run {
+                self?.reconnectPublisher.send(())
+            }
+        }
+    }
+}
+
+extension MultiThreadedEventLoopGroup {
+    static var singleton: MultiThreadedEventLoopGroup = {
+        MultiThreadedEventLoopGroup(numberOfThreads: 1)
+    }()
+}
+
+extension MQTTWatchClient {
+    enum EventLoopProvider {
+        case createNew
+        case shared(EventLoopGroup)
+        case singleton
+    }
+
+    enum MQTTWatchError: Error {
+        case notConnected
+    }
+}

--- a/WatchMQTTSample/WatchMQTTSample/MQTTWatchSampleApp.swift
+++ b/WatchMQTTSample/WatchMQTTSample/MQTTWatchSampleApp.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+import WatchKit
+
+final class AppDelegate: NSObject, WKApplicationDelegate {
+    private var backgroundTask: WKRefreshBackgroundTask?
+
+    func applicationDidBecomeActive() {
+        WKExtension.shared().isFrontmostTimeoutExtended = true
+    }
+
+    func handle(_ backgroundTasks: Set<WKRefreshBackgroundTask>) {
+        for task in backgroundTasks {
+            backgroundTask = task
+            task.setTaskCompletedWithSnapshot(false)
+        }
+    }
+}
+
+@main
+struct MQTTWatchSampleApp: App {
+    @WKApplicationDelegateAdaptor(AppDelegate.self) private var delegate
+    @StateObject private var mqttClient = MQTTWatchClient()
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environmentObject(mqttClient)
+        }
+    }
+}

--- a/WatchMQTTSample/WatchMQTTSample/MessageEntry.swift
+++ b/WatchMQTTSample/WatchMQTTSample/MessageEntry.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+struct MessageEntry: Identifiable, Equatable {
+    let id = UUID()
+    let topic: String
+    let payload: String
+    let timestamp: Date
+}


### PR DESCRIPTION
## Summary
- add a SwiftUI-based watchOS sample app that connects to an MQTT broker via MQTTNio over WebSockets
- display connection state, incoming watch/# messages, and provide a "Hello MQTT!" publisher button
- document the integration and setup steps for running the watch app independently over LTE

## Testing
- not run (not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68cd4512b3dc832991b89b31b878641f